### PR TITLE
fix(payments): mark /my-account/payments page as dynamic to support s…

### DIFF
--- a/app/(dashboards)/my-account/courses/page.tsx
+++ b/app/(dashboards)/my-account/courses/page.tsx
@@ -1,31 +1,32 @@
+export const dynamic = "force-dynamic";
 import { getUserPurchasedCoursesAction } from "@/actions/courses/get-user-purchased-courses.action";
 import { toPersianNumber } from "@/utils";
 import { SectionBlock } from "@/components/dashboard/SectionBlock";
 import { DashboardPurchasedCourseCard } from "@/components/dashboard/DashboardPurchasedCourseCard";
 
-export default async function UserCoursesPage() {
+const UserCoursesPage = async () => {
   const courses = await getUserPurchasedCoursesAction();
 
   if (!courses || !courses.length) {
     return null;
   }
   return (
-    <>
-      <SectionBlock title={`دوره های من (${toPersianNumber(courses?.length)})`}>
-        <div className="grid grid-cols-4 gap-4">
-          {courses?.map((course) => (
-            <DashboardPurchasedCourseCard
-              key={course.id}
-              id={course.id}
-              slug={course.slug}
-              title={course.title}
-              description={course.description}
-              imageUrl={course.imageUrl}
-              instructor={course.instructor}
-            />
-          ))}
-        </div>
-      </SectionBlock>
-    </>
+    <SectionBlock title={`دوره های من (${toPersianNumber(courses?.length)})`}>
+      <div className="grid grid-cols-4 gap-4">
+        {courses?.map((course) => (
+          <DashboardPurchasedCourseCard
+            key={course.id}
+            id={course.id}
+            slug={course.slug}
+            title={course.title}
+            description={course.description}
+            imageUrl={course.imageUrl}
+            instructor={course.instructor}
+          />
+        ))}
+      </div>
+    </SectionBlock>
   );
-}
+};
+
+export default UserCoursesPage;

--- a/app/(dashboards)/my-account/page.tsx
+++ b/app/(dashboards)/my-account/page.tsx
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { DashboardStatBox } from "@/components/dashboard/DashboardStatBox";
 
 import { TooltipWrapper } from "@/components/common/TooltipWrapper";

--- a/app/(dashboards)/my-account/payments/page.tsx
+++ b/app/(dashboards)/my-account/payments/page.tsx
@@ -1,20 +1,22 @@
+export const dynamic = "force-dynamic";
 import { getUserOrdersAction } from "@/actions/order/get-user-orders.action";
 import { ClientToastWrapper } from "@/components/common/ClientToastWrapper";
 import { PaymentTable } from "@/components/tables/PaymentTable";
 
-export default async function UserPaymentPage() {
+const UserPaymentPage = async () => {
   const response = await getUserOrdersAction();
   if (response.error) {
     return <ClientToastWrapper message={response.error} />;
   }
+
   const { orders } = response;
   return (
-    <>
-      <div className="py-6">
-        <h2 className="text-lg font-bold mb-4">لیست پرداخت‌ها</h2>
+    <div className="py-6">
+      <h2 className="text-lg font-bold mb-4">لیست پرداخت‌ها</h2>
 
-        <PaymentTable data={orders ?? []} />
-      </div>
-    </>
+      <PaymentTable data={orders ?? []} />
+    </div>
   );
-}
+};
+
+export default UserPaymentPage;


### PR DESCRIPTION
…ession-based user orders

- Added `export const dynamic = "force-dynamic"` to payments page
- Prevents Next.js from attempting static rendering where `currentUser()` relies on headers/cookies
- Ensures user-specific order data loads correctly in production